### PR TITLE
商品削除機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new]
-  before_action :find_item, only: [:show, :edit, :update]
+  before_action :authenticate_user!, only: [:new, :destroy]
+  before_action :find_item, only: [:show, :edit, :update, :destroy]
 
   def index
     @items = Item.order('created_at DESC')
@@ -39,6 +39,14 @@ class ItemsController < ApplicationController
     end
   end
 
+  def destroy
+    if current_user == @item.user
+      @item.destroy
+      redirect_to root_path
+    else
+      redirect_to item_path(@item)
+    end
+  end
 
   private
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -39,6 +39,7 @@ class ItemsController < ApplicationController
     end
   end
 
+
   private
 
   def item_params

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -23,7 +23,7 @@
     <% if user_signed_in? && current_user.id == @item.user_id %>
     <%= link_to "商品の編集", edit_item_path, method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
-    <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+    <%= link_to "削除", item_path, data: { turbo_method: :delete }, class:"item-destroy" %>
     <% end %>
 
     <% if user_signed_in? && current_user.id != @item.user_id %>


### PR DESCRIPTION
# What
商品削除機能の実装

# Why
商品削除機能の実装のため
[ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる](https://gyazo.com/91d72e6e75e58a8dfb96ad7aa838f767)